### PR TITLE
Ap blocks when derived from chain, this rewrites it to not do so

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -128,10 +128,17 @@ Task.prototype.chain = function _chain(f) {
  * @summary @Task[α, (β → γ)] => Task[α, β] → Task[α, γ]
  */
 
-Task.prototype.ap = function _ap(f2) {
-  return this.chain(function(f) {
-    return f2.map(f);
-  });
+Task.prototype.ap = function _ap(a) {
+  var fork = this.fork;
+  var cleanup = this.cleanup;
+
+  return new Task(function(reject, resolve) {
+    return fork(function(a) {
+      return reject(a);
+    }, function(f) {
+      return a.map(f).fork(reject, resolve);
+    });
+  }, cleanup);
 };
 
 // -- Semigroup ------------------------------------------------------------


### PR DESCRIPTION
Was easy enough so I figured I'd just go for it. No worries if this is going to clash in the redesign.