### PR TITLE
Rewrote `ap` to be parallel instead of using sequential `chain`

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -142,20 +142,25 @@ Task.prototype.ap = function _ap(that) {
   return new Task(function(reject, resolve) {
     var func, funcLoaded = false;
     var val, valLoaded = false;
+    var rejected = false;
     var allState;
 
-    var thisState = forkThis(reject, guard(function(x) {
+    var thisState = forkThis(guardReject, guardResolve(function(x) {
       funcLoaded = true;
       func = x;
     }));
 
-    var thatState = forkThat(reject, guard(function(x) {
+    var thatState = forkThat(guardReject, guardResolve(function(x) {
       valLoaded = true;
       val = x;
     }));
 
-    function guard(setter) {
+    function guardResolve(setter) {
       return function(x) {
+        if (rejected) {
+          return;
+        }
+
         setter(x);
         if (funcLoaded && valLoaded) {
           delayed(function(){ cleanupBoth(allState) });
@@ -163,6 +168,13 @@ Task.prototype.ap = function _ap(that) {
         } else {
           return x;
         }
+      }
+    }
+
+    function guardReject(x) {
+      if (!rejected) {
+        rejected = true;
+        return reject(x);
       }
     }
 

--- a/lib/task.js
+++ b/lib/task.js
@@ -128,10 +128,46 @@ Task.prototype.chain = function _chain(f) {
  * @summary @Task[α, (β → γ)] => Task[α, β] → Task[α, γ]
  */
 
-Task.prototype.ap = function _ap(f2) {
-  return this.chain(function(f) {
-    return f2.map(f);
-  });
+Task.prototype.ap = function _ap(that) {
+  var forkThis = this.fork;
+  var forkThat = that.fork;
+  var cleanupThis = this.cleanup;
+  var cleanupThat = that.cleanup;
+
+  function cleanupBoth(state) {
+    cleanupThis(state[0]);
+    cleanupThat(state[1]);
+  }
+
+  return new Task(function(reject, resolve) {
+    var func, funcLoaded = false;
+    var val, valLoaded = false;
+    var allState;
+
+    var thisState = forkThis(reject, guard(function(x) {
+      funcLoaded = true;
+      func = x;
+    }));
+
+    var thatState = forkThat(reject, guard(function(x) {
+      valLoaded = true;
+      val = x;
+    }));
+
+    function guard(setter) {
+      return function(x) {
+        setter(x);
+        if (funcLoaded && valLoaded) {
+          delayed(function(){ cleanupBoth(allState) });
+          return resolve(func(val));
+        } else {
+          return x;
+        }
+      }
+    }
+
+    return allState = [thisState, thatState];
+  }, cleanupBoth);
 };
 
 // -- Semigroup ------------------------------------------------------------


### PR DESCRIPTION
If you have Array of Tasks and want transform it into Task of Array using traverse or sequence, tasks will be forked sequentially instead of parallel.
The reason is that `ap` is implemented using sequential `chain` method. Here it is rewritten to be parallel.