### PR TITLE
Stop publishing non-production files to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
 dist/
+test/
+tools/
+Makefile


### PR DESCRIPTION
Fixes #36.

Went ahead and added the `Makefile` and npm verion bumping script—no problem if you want me to keep those. I was mostly interested in not publishing tests 😄 